### PR TITLE
Added disabled property for BaseButton

### DIFF
--- a/front-end/src/components/BaseButton.jsx
+++ b/front-end/src/components/BaseButton.jsx
@@ -2,12 +2,22 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const BaseButton = (props) => {
+    // Change button appearance based on whether it is enabled or disabled
+    const style = () => {
+        if (props.isDisabled) {
+            return "bg-blue-300 rounded-lg shadow-lg opacity-50 py-3 px-6";
+        } else {
+            return "bg-blue-300 rounded-lg shadow-lg hover:bg-blue-200 active:bg-blue-400 py-3 px-6";
+        }
+    };
+
     return (
         <div className='flex'>
             <button
                 onClick={props.click}
-                className="bg-blue-300 rounded-lg shadow-lg hover:bg-blue-200 active:bg-blue-400 py-3 px-6"
+                className={style()}
                 data-testid="custom-button"
+                disabled={props.isDisabled}
             > 
                 { props.text }
             </button>
@@ -18,6 +28,11 @@ const BaseButton = (props) => {
 BaseButton.propTypes = {
     text: PropTypes.string,
     click: PropTypes.func.isRequired,
+    isDisabled: PropTypes.bool,
+}
+
+BaseButton.defaultProps = {
+    isDisabled: false,
 }
 
 export default BaseButton;

--- a/front-end/src/components/BaseButton.jsx
+++ b/front-end/src/components/BaseButton.jsx
@@ -3,19 +3,18 @@ import PropTypes from 'prop-types';
 
 const BaseButton = (props) => {
     // Change button appearance based on whether it is enabled or disabled
-    const style = () => {
-        if (props.isDisabled) {
-            return "bg-blue-300 rounded-lg shadow-lg opacity-50 py-3 px-6";
-        } else {
-            return "bg-blue-300 rounded-lg shadow-lg hover:bg-blue-200 active:bg-blue-400 py-3 px-6";
-        }
+    const getButtonStyle = () => {
+        const baseStyling = "bg-blue-300 rounded-lg shadow-lg py-3 px-6 ";
+        const disabledStyling = "opacity-50";
+        const enabledStyling = "hover:bg-blue-200 active:bg-blue-400";
+        return baseStyling + (props.isDisabled ? disabledStyling : enabledStyling);
     };
 
     return (
         <div className='flex'>
             <button
                 onClick={props.click}
-                className={style()}
+                className={getButtonStyle()}
                 data-testid="custom-button"
                 disabled={props.isDisabled}
             > 

--- a/front-end/src/components/BaseButton.test.js
+++ b/front-end/src/components/BaseButton.test.js
@@ -31,7 +31,7 @@ describe('BaseButton tests', () => {
 
     it('should have correct style if isDisabled is false', async() => {
         renderComponent(basicProps, false);
-        expect(screen.getByTestId('custom-button')).toHaveClass("bg-blue-300 rounded-lg shadow-lg hover:bg-blue-200 active:bg-blue-400 py-3 px-6");
+        expect(screen.getByTestId('custom-button')).toHaveClass("bg-blue-300 rounded-lg shadow-lg py-3 px-6 hover:bg-blue-200 active:bg-blue-400");
     });
 
     it('should not be disabled if isDisabled is false', async() => {
@@ -41,7 +41,7 @@ describe('BaseButton tests', () => {
 
     it('should have correct style if isDisabled is true', async() => {
         renderComponent(basicProps, true);
-        expect(screen.getByTestId('custom-button')).toHaveClass("bg-blue-300 rounded-lg shadow-lg opacity-50 py-3 px-6");
+        expect(screen.getByTestId('custom-button')).toHaveClass("bg-blue-300 rounded-lg shadow-lg py-3 px-6 opacity-50");
     });
 
     it('should be disabled if isDisabled is true', async() => {

--- a/front-end/src/components/BaseButton.test.js
+++ b/front-end/src/components/BaseButton.test.js
@@ -14,8 +14,8 @@ describe('BaseButton tests', () => {
         click: jest.fn(),
         text: "sampleText",
     };
-    const renderComponent = (props, componentDisabled) => {
-        render(<BaseButton {... props} isDisabled={componentDisabled}/>)
+    const renderComponent = (props, buttonDisabled) => {
+        render(<BaseButton {... props} isDisabled={buttonDisabled}/>)
     }
 
     it('should call the click function on click', () => {

--- a/front-end/src/components/BaseButton.test.js
+++ b/front-end/src/components/BaseButton.test.js
@@ -14,19 +14,39 @@ describe('BaseButton tests', () => {
         click: jest.fn(),
         text: "sampleText",
     };
-    const renderComponent = (props) => {
-        render(<BaseButton {... props}/>)
+    const renderComponent = (props, componentDisabled) => {
+        render(<BaseButton {... props} isDisabled={componentDisabled}/>)
     }
 
     it('should call the click function on click', () => {
-        renderComponent(basicProps);
+        renderComponent(basicProps, false);
         userEvent.click(screen.getByTestId('custom-button'));
         expect(basicProps.click).toHaveBeenCalled();
     });
 
     it('should display the given text', async() => {
-        renderComponent(basicProps);
+        renderComponent(basicProps, false);
         expect(await screen.findByTestId("custom-button")).toHaveTextContent(basicProps.text);
+    });
+
+    it('should have correct style if isDisabled is false', async() => {
+        renderComponent(basicProps, false);
+        expect(screen.getByTestId('custom-button')).toHaveClass("bg-blue-300 rounded-lg shadow-lg hover:bg-blue-200 active:bg-blue-400 py-3 px-6");
+    });
+
+    it('should not be disabled if isDisabled is false', async() => {
+        renderComponent(basicProps, false);
+        expect(screen.getByTestId('custom-button')).not.toBeDisabled();
+    });
+
+    it('should have correct style if isDisabled is true', async() => {
+        renderComponent(basicProps, true);
+        expect(screen.getByTestId('custom-button')).toHaveClass("bg-blue-300 rounded-lg shadow-lg opacity-50 py-3 px-6");
+    });
+
+    it('should be disabled if isDisabled is true', async() => {
+        renderComponent(basicProps, true);
+        expect(screen.getByTestId('custom-button')).toBeDisabled();
     });
 
 });

--- a/front-end/src/components/MainPage.jsx
+++ b/front-end/src/components/MainPage.jsx
@@ -32,7 +32,8 @@ class MainPage extends Component {
           <div className="justify-center flex">
             <BaseButton
               click={this.toggleTranscriptUploadModal}
-              text="Upload Transcript" />
+              text="Upload Transcript"
+            />
           </div>
           <div className="justify-center flex">
             <TranscriptUploadModal
@@ -43,7 +44,8 @@ class MainPage extends Component {
           <div className="justify-center flex">
             <BaseButton
               click={this.openAnalysisPage}
-              text="View Analysis"/>
+              text="View Analysis"
+            />
           </div>
           <div className="justify-center flex">
             <IntentDiagram question="test question" branches={fakeChildren}/>


### PR DESCRIPTION
## Pull Request Summary
New props field for BaseButton called "isDisabled" which determines whether the button is disabled and grayed out.

Instead of being actually grayed out, I set it to 50% opacity as per this article: https://uxmovement.com/buttons/why-you-shouldnt-gray-out-disabled-buttons/.

Note: this does not actually disable any buttons on the page because that's a separate ticket.

### Change types
- [x] Non-breaking change
- [x] Adding tests
- [x] Front end change

### Testing
- [x] I have added testing to this PR

### How to manually test this PR (QA instructions)
By default, the View Analysis button should be disabled when no transcript has been uploaded yet. But that's a different ticket, so right now there is no disabled button to manually test. If you want, you can add "isDisabled={true}" as a tag to one of the buttons on MainPage to see what it should look like. Otherwise, see the screenshot below for a comparison:
![image](https://user-images.githubusercontent.com/69657338/197419990-f1f8120c-ffc3-4dd6-86b2-701c89f2a380.png)

## Questions
<!--Put any questions you want to ask here (mainly used to allow others to see your code)-->
I think the article above makes a compelling case for why transparent buttons > grayed out, but I don't think it looks that great right now. I'm hoping it will look better once we get the formalized color palette, so can we keep the low-opacity styling for disabled buttons until then? If it looks bad with the palette too, then we should consider actually making the button gray. There's a chance that this will happen since I feel transparency doesn't translate too well to the flat-ish design our UI has.