### PR TITLE
Get analyzed transcript by project ID

### DIFF
--- a/front-end/src/App.test.js
+++ b/front-end/src/App.test.js
@@ -27,11 +27,10 @@ describe('App', () => {
         expect(screen.queryByTestId('analysis-page')).not.toBeInTheDocument();
     });
     
-    it('should display AnalysisPage when a transcript has been uploaded and analyzed successfully and View Analysis button is pressed on MainPage', async() => {
-        store.dispatch(setTranscriptUploadStatus(true));
-        store.dispatch(setProjectIdToBeDisplayed("1"));
+    it('should display AnalysisPage when a transcript has been uploaded and analyzed successfully and View Analysis button is pressed on MainPage with a valid Project ID', async() => {
         store.dispatch(addAnalyzedTranscript({projectId: "1", transcript: [{question: "a", children: {"b": 100,}}]}));
         renderComponent();
+        userEvent.type(screen.getByLabelText("Enter Project ID"), "1");
         userEvent.click(screen.getByText('View Analysis'));
         await screen.findByTestId('analysis-page');
         expect(screen.queryByTestId('main-page')).not.toBeInTheDocument();

--- a/front-end/src/App.test.js
+++ b/front-end/src/App.test.js
@@ -28,6 +28,7 @@ describe('App', () => {
     });
     
     it('should display AnalysisPage when a transcript has been uploaded and analyzed successfully and View Analysis button is pressed on MainPage with a valid Project ID', async() => {
+        store.dispatch(setTranscriptUploadStatus(true));
         store.dispatch(addAnalyzedTranscript({projectId: "1", transcript: [{question: "a", children: {"b": 100,}}]}));
         renderComponent();
         userEvent.type(screen.getByLabelText("Enter Project ID"), "1");

--- a/front-end/src/components/analysis-page/IntentLister.jsx
+++ b/front-end/src/components/analysis-page/IntentLister.jsx
@@ -193,6 +193,6 @@ IntentLister.defaultProps = {
 const mapStateToProps = (state, ownProps) =>({
     index: state.analyzeTranscript.DisplayingQuestion[state.analyzeTranscript.projectIdToBeDisplayed],
     intents: ownProps.intents
-  });
+});
   
 export default connect(mapStateToProps)(IntentLister);

--- a/front-end/src/components/general/BaseButton.jsx
+++ b/front-end/src/components/general/BaseButton.jsx
@@ -33,7 +33,7 @@ const BaseButton = (props) => {
                 onClick={props.click}
                 className={getButtonStyle()}
                 disabled={props.isDisabled}
-                aria-label={props.text || props.label}
+                aria-label={props.label || props.text}
                 data-testid="custom-button"
             >
                 <div className="flex items-center space-x-2">

--- a/front-end/src/components/general/BaseButton.jsx
+++ b/front-end/src/components/general/BaseButton.jsx
@@ -33,7 +33,7 @@ const BaseButton = (props) => {
                 onClick={props.click}
                 className={getButtonStyle()}
                 disabled={props.isDisabled}
-                aria-label={props.label}
+                aria-label={props.text || props.label}
                 data-testid="custom-button"
             >
                 <div className="flex items-center space-x-2">

--- a/front-end/src/components/general/BaseButton.test.js
+++ b/front-end/src/components/general/BaseButton.test.js
@@ -49,15 +49,15 @@ describe("BaseButton", () => {
         expect(await screen.findByTestId("custom-button")).toHaveTextContent(props.text);
     });
 
-    it("should have an aria label matching the given text if there is any", async() => {
-        renderComponent(props);
-        expect(await screen.findByTestId("custom-button")).toHaveAttribute("aria-label", props.text);
-    });
-
-    it("should have the given aria label if there is no given text", async() => {
-        props.text = null;
+    it("should have the given aria label", async() => {
         renderComponent(props);
         expect(await screen.findByTestId("custom-button")).toHaveAttribute("aria-label", props.label);
+    });
+
+    it("should have an aria label matching the given text if there is no label", async() => {
+        props.label = null;
+        renderComponent(props);
+        expect(await screen.findByTestId("custom-button")).toHaveAttribute("aria-label", props.text);
     });
 
     it("should have a tooltip if tooltip prop is not null", () => {

--- a/front-end/src/components/general/BaseButton.test.js
+++ b/front-end/src/components/general/BaseButton.test.js
@@ -49,7 +49,13 @@ describe("BaseButton", () => {
         expect(await screen.findByTestId("custom-button")).toHaveTextContent(props.text);
     });
 
-    it("should have the given aria label", async() => {
+    it("should have an aria label matching the given text if there is any", async() => {
+        renderComponent(props);
+        expect(await screen.findByTestId("custom-button")).toHaveAttribute("aria-label", props.text);
+    });
+
+    it("should have the given aria label if there is no given text", async() => {
+        props.text = null;
         renderComponent(props);
         expect(await screen.findByTestId("custom-button")).toHaveAttribute("aria-label", props.label);
     });

--- a/front-end/src/components/main-page/MainPage.jsx
+++ b/front-end/src/components/main-page/MainPage.jsx
@@ -31,7 +31,7 @@ class MainPage extends Component {
     this.setState({inputValue: event.target.value});
   }
 
-  checkIfInputIsBlank() {
+  isInputBlank() {
     // Return whether the input field is blank. If so, it disables the View Analysis button
     return this.state.inputValue === "";
   }
@@ -40,9 +40,7 @@ class MainPage extends Component {
     try {
       await this.getAnalyzedData();
       store.dispatch(openAnalysisPage());
-      console.log("hi5")
     } catch (e) {
-      console.log("hi4")
       window.alert("Error in analyzing transcript. " + e.response.data.error);
     }
   }
@@ -51,23 +49,18 @@ class MainPage extends Component {
       const override = store.getState().analyzeTranscript.override;
       const projectId = store.getState().analyzeTranscript.projectIdToBeDisplayed;
       const analyzedTranscripts = store.getState().analyzeTranscript.analyzedTranscripts;
-      console.log("hi1")
       console.log(projectId)
       if(override || (!(projectId in analyzedTranscripts))){
         // Call API if either the user wants to override or the project ID is not stored in this session's transcripts
-        console.log('hi1.5')
         const analyzedData = await TranscriptAPI.getAnalysis({project_id: projectId});
-        console.log("hi2")
         if (analyzedData.data.length === 0) {
           // Throw an error if getAnalysis returns an empty array, as this means no transcript with that project ID was found
           const missingIdError = new Error();
           missingIdError.response = {data: {error: "Your project ID was not in our database. Please try again."}}
-          console.log("hi3")
           throw missingIdError;
         } else {
           store.dispatch(addAnalyzedTranscript({projectId: projectId, transcript: analyzedData.data}));
           store.dispatch(setOverrideStatus(false));
-          console.log("hi6")
         }
       }
   }
@@ -127,7 +120,7 @@ class MainPage extends Component {
                 click={this.openAnalysisPage}
                 text="View Analysis"
                 size="lg"
-                isDisabled={this.checkIfInputIsBlank()}
+                isDisabled={this.isInputBlank()}
                 icon={{
                   name: "analyze-note",
                   size: "40"

--- a/front-end/src/components/main-page/MainPage.jsx
+++ b/front-end/src/components/main-page/MainPage.jsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { connect } from "react-redux";
 import store from "../../store.js";
 import { openAnalysisPage } from "../../store/switchPageSlice.js";
-import { addAnalyzedTranscript, setOverrideStatus } from '../../store/analyzeTranscriptSlice.js';
+import { addAnalyzedTranscript, setOverrideStatus, setProjectIdToBeDisplayed } from '../../store/analyzeTranscriptSlice.js';
 import BaseButton from "../general/BaseButton.jsx";
 import TranscriptUploadModal from "./TranscriptUploadModal.jsx";
 import Title from "../icons/title.jsx";
@@ -12,12 +12,22 @@ import TranscriptAPI from "../../services/TranscriptAPI.js";
 
 
 class MainPage extends Component {
-  state = {
-    showTranscriptUploadModal: false
+
+  constructor() {
+    super();
+    this.handleChange = this.handleChange.bind(this);
+    this.state = {
+      showTranscriptUploadModal: false,
+    };
   }
 
   toggleTranscriptUploadModal = () => {
     this.setState({showTranscriptUploadModal: !this.state.showTranscriptUploadModal});
+  }
+
+  handleChange = (event) => {
+    // Update the Project ID of the analyzed transcript to display in redux based on input field
+    store.dispatch(setProjectIdToBeDisplayed(event.target.value));
   }
 
   openAnalysisPage = async() => {
@@ -29,7 +39,7 @@ class MainPage extends Component {
     }
   }
 
-  getAnalyzedData = async() =>{
+  getAnalyzedData = async() => {
       const override = store.getState().analyzeTranscript.override;
       const projectId = store.getState().analyzeTranscript.projectIdToBeDisplayed;
       const transcripts = store.getState().analyzeTranscript.analyzedTranscripts;
@@ -78,7 +88,13 @@ class MainPage extends Component {
                 }}
               />
             </div>
-            <div className="justify-center flex">
+            <div className="justify-center flex flex-col sm:flex-row">
+              <div className="absolute py-32">
+                <input
+                  onChange={this.handleChange}
+                  value={this.state.projectId}
+                />
+              </div>      
               <BaseButton
                 click={this.openAnalysisPage}
                 text="View Analysis"

--- a/front-end/src/components/main-page/MainPage.jsx
+++ b/front-end/src/components/main-page/MainPage.jsx
@@ -40,7 +40,9 @@ class MainPage extends Component {
     try {
       await this.getAnalyzedData();
       store.dispatch(openAnalysisPage());
+      console.log("hi5")
     } catch (e) {
+      console.log("hi4")
       window.alert("Error in analyzing transcript. " + e.response.data.error);
     }
   }
@@ -49,17 +51,23 @@ class MainPage extends Component {
       const override = store.getState().analyzeTranscript.override;
       const projectId = store.getState().analyzeTranscript.projectIdToBeDisplayed;
       const analyzedTranscripts = store.getState().analyzeTranscript.analyzedTranscripts;
+      console.log("hi1")
+      console.log(projectId)
       if(override || (!(projectId in analyzedTranscripts))){
         // Call API if either the user wants to override or the project ID is not stored in this session's transcripts
+        console.log('hi1.5')
         const analyzedData = await TranscriptAPI.getAnalysis({project_id: projectId});
+        console.log("hi2")
         if (analyzedData.data.length === 0) {
           // Throw an error if getAnalysis returns an empty array, as this means no transcript with that project ID was found
           const missingIdError = new Error();
           missingIdError.response = {data: {error: "Your project ID was not in our database. Please try again."}}
+          console.log("hi3")
           throw missingIdError;
         } else {
           store.dispatch(addAnalyzedTranscript({projectId: projectId, transcript: analyzedData.data}));
           store.dispatch(setOverrideStatus(false));
+          console.log("hi6")
         }
       }
   }

--- a/front-end/src/components/main-page/MainPage.jsx
+++ b/front-end/src/components/main-page/MainPage.jsx
@@ -101,17 +101,25 @@ class MainPage extends Component {
             </div>
             <div className="justify-center flex flex-col sm:flex-row">
               <div className="absolute py-32">
-                <input
-                  className="bg-off-white text-xl rounded-md px-4 py-2 drop-shadow-md outline-none transition ease-in-out
-                  border border-solid border-purple-100
-                  hover:border-purple-200
-                  focus:border-purple-300 focus:ring-purple-300"
-                  aria-label="Enter Project ID"
-                  placeholder="Enter Project ID"
-                  onChange={this.handleChange}
-                  value={this.props.projectIdToBeDisplayed}
-                  title="Each transcript has a unique Project ID that you can enter to specify which analysis to view."
-                />
+                <div className="group">
+                  <input
+                    className="bg-off-white text-xl rounded-md px-4 py-2 drop-shadow-md outline-none transition ease-in-out
+                    border border-solid border-purple-100
+                    hover:border-purple-200
+                    focus:border-purple-300 focus:ring-purple-300"
+                    aria-label="Enter Project ID"
+                    placeholder="Enter Project ID"
+                    onChange={this.handleChange}
+                    value={this.props.projectIdToBeDisplayed}
+                  />
+                  <div className="group-hover:flex">
+                    <span
+                      className="absolute hidden group-hover:flex right-16 -bottom-4 -translate-y-full w-32 px-2 py-1 bg-gray rounded-lg text-center text-off-white text-sm after:content-[''] after:rotate-180 after:absolute after:left-1/2 after:-top-[22%] after:-translate-x-1/2 after:border-8 after:border-x-transparent after:border-b-transparent after:border-t-gray"
+                    >
+                      Enter the Project ID that you want to analyze
+                    </span>
+                  </div>
+                </div>
               </div>      
               <BaseButton
                 click={this.openAnalysisPage}

--- a/front-end/src/components/main-page/MainPage.test.js
+++ b/front-end/src/components/main-page/MainPage.test.js
@@ -15,7 +15,7 @@ describe('MainPage', () => {
     );
 
     afterAll(() => {
-        // restoring the store to default
+        // Restore the store to default
         store.dispatch(setTranscriptUploadStatus(false));
         store.dispatch(clearAnalyzedTranscript());
         store.dispatch(setProjectIdToBeDisplayed(""));
@@ -34,8 +34,8 @@ describe('MainPage', () => {
         expect(screen.queryByText("Drag and drop file or upload below.")).not.toBeInTheDocument();
     });
 
-    it('should dispatch openAnalysisPage when View Analysis button is clicked', async() => {
-        store.dispatch(setTranscriptUploadStatus(true));
+    it('should dispatch openAnalysisPage when valid Project ID is entered and View Analysis button is clicked', async() => {
+        //store.dispatch(setTranscriptUploadStatus(true));
         store.dispatch(setProjectIdToBeDisplayed("1"));
         store.dispatch(addAnalyzedTranscript({projectId: "1", transcript: [{question: "a", children: {"b": 100,}}]}));
         renderComponent();

--- a/front-end/src/components/main-page/MainPage.test.js
+++ b/front-end/src/components/main-page/MainPage.test.js
@@ -6,6 +6,9 @@ import store from '../../store.js';
 import MainPage from './MainPage.jsx';
 import {setTranscriptUploadStatus} from "../../store/transcriptUploadSlice.js";
 import {setProjectIdToBeDisplayed, addAnalyzedTranscript, clearAnalyzedTranscript} from "../../store/analyzeTranscriptSlice.js"
+import TranscriptAPI from "../../services/TranscriptAPI.js";
+
+jest.mock("../../services/TranscriptAPI.js");
 
 describe('MainPage', () => {
     const renderComponent = () => render(
@@ -34,15 +37,53 @@ describe('MainPage', () => {
         expect(screen.queryByText("Drag and drop file or upload below.")).not.toBeInTheDocument();
     });
 
+    it('should dispatch setProjectIdToBeDisplayed with correct Project ID if a Project ID is entered', async() => {
+        renderComponent();
+        const dispatch = jest.spyOn(store, 'dispatch');
+        userEvent.type(screen.getByLabelText("Enter Project ID"), "1");
+        expect(dispatch).toHaveBeenCalledWith({ type: 'analyzeTranscript/setProjectIdToBeDisplayed', payload: '1'});
+    });
+
+    it('should enable View Analysis button if a Project ID is entered', async() => {
+        renderComponent();
+        userEvent.type(screen.getByLabelText("Enter Project ID"), "1");
+        expect(screen.getByLabelText("View Analysis")).not.toBeDisabled();
+    });
+
+    it('should disable View Analysis button if no Project ID is entered', async() => {
+        renderComponent();
+        expect(screen.getByLabelText("View Analysis")).toBeDisabled();
+    });
+
     it('should dispatch openAnalysisPage when valid Project ID is entered and View Analysis button is clicked', async() => {
-        //store.dispatch(setTranscriptUploadStatus(true));
-        store.dispatch(setProjectIdToBeDisplayed("1"));
         store.dispatch(addAnalyzedTranscript({projectId: "1", transcript: [{question: "a", children: {"b": 100,}}]}));
         renderComponent();
         const dispatch = jest.spyOn(store, 'dispatch');
+        userEvent.type(screen.getByLabelText("Enter Project ID"), "1");
         await userEvent.click(screen.getByText('View Analysis'));
         expect(dispatch).toHaveBeenCalledWith({ type: 'switchPage/openAnalysisPage' });
     });
+
+    it('should show an alert and not dispatch openAnalysisPage when invalid Project ID is entered and View Analysis button is clicked', async() => {
+        const mockAlert = jest.spyOn(global, "alert").mockImplementation(); 
+        jest.spyOn(TranscriptAPI, "getAnalysis").mockImplementationOnce(() => {return []});
+        store.dispatch(addAnalyzedTranscript({projectId: "1", transcript: [{question: "a", children: {"b": 100,}}]}));
+        renderComponent();
+        const dispatch = jest.spyOn(store, 'dispatch');
+        userEvent.type(screen.getByLabelText("Enter Project ID"), "2");
+        await userEvent.click(screen.getByText('View Analysis'));
+        expect(mockAlert).toHaveBeenCalledWith("Error in analyzing transcript. Your project ID was not in our database. Please try again.");
+        expect(dispatch).not.toHaveBeenCalledWith({ type: 'switchPage/openAnalysisPage' });
+    });
+
+    it.only("should dispatch addAnalyzedTranscript when valid Project ID is entered and View Analysis button is clicked but the Project ID is not stored in this session's transcripts", async() => {
+        jest.spyOn(TranscriptAPI, "getAnalysis").mockImplementationOnce(() => {return [{question: "a", children: {"b": 100,}}]});
+        renderComponent();
+        const dispatch = jest.spyOn(store, 'dispatch');
+        userEvent.type(screen.getByLabelText("Enter Project ID"), "1");
+        await userEvent.click(screen.getByText('View Analysis'));
+        expect(dispatch).toHaveBeenCalledWith({ type: 'switchPage/openAnalysisPage' });
+    });        
 
     it('should download transcript template when Download Transcript Template button is clicked', () => {
         renderComponent();

--- a/front-end/src/components/main-page/MainPage.test.js
+++ b/front-end/src/components/main-page/MainPage.test.js
@@ -41,21 +41,30 @@ describe('MainPage', () => {
         expect(screen.queryByText("Drag and drop file or upload below.")).not.toBeInTheDocument();
     });
 
-    it('should dispatch setProjectIdToBeDisplayed with correct Project ID if a Project ID is entered', async() => {
+    it('should dispatch setProjectIdToBeDisplayed with correct Project ID if a Project ID is entered', () => {
         renderComponent();
         const dispatch = jest.spyOn(store, 'dispatch');
+        userEvent.clear(screen.getByLabelText("Enter Project ID"));
         userEvent.type(screen.getByLabelText("Enter Project ID"), "1");
         expect(dispatch).toHaveBeenCalledWith({ type: 'analyzeTranscript/setProjectIdToBeDisplayed', payload: '1'});
     });
 
-    it('should enable View Analysis button if a Project ID is entered', async() => {
+    it('should automatically write the current Project ID into the Project ID input', async() => {
+        store.dispatch(setProjectIdToBeDisplayed("Most recent Project ID"));
         renderComponent();
+        expect(screen.getByDisplayValue("Most recent Project ID")).toBeInTheDocument();
+    });
+
+    it('should enable View Analysis button if a Project ID is entered', () => {
+        renderComponent();
+        userEvent.clear(screen.getByLabelText("Enter Project ID"));
         userEvent.type(screen.getByLabelText("Enter Project ID"), "1");
         expect(screen.getByLabelText("View Analysis")).not.toBeDisabled();
     });
 
-    it('should disable View Analysis button if no Project ID is entered', async() => {
+    it('should disable View Analysis button if no Project ID is entered', () => {
         renderComponent();
+        userEvent.clear(screen.getByLabelText("Enter Project ID"));
         expect(screen.getByLabelText("View Analysis")).toBeDisabled();
     });
 
@@ -63,6 +72,7 @@ describe('MainPage', () => {
         store.dispatch(addAnalyzedTranscript({projectId: "1", transcript: [{question: "a", children: {"b": 100,}}]}));
         renderComponent();
         const dispatch = jest.spyOn(store, 'dispatch');
+        userEvent.clear(screen.getByLabelText("Enter Project ID"));
         userEvent.type(screen.getByLabelText("Enter Project ID"), "1");
         await userEvent.click(screen.getByText('View Analysis'));
         expect(dispatch).toHaveBeenCalledWith({ type: 'switchPage/openAnalysisPage' });
@@ -73,6 +83,7 @@ describe('MainPage', () => {
         store.dispatch(addAnalyzedTranscript({projectId: "1", transcript: [{question: "a", children: {"b": 100,}}]}));
         renderComponent();
         const dispatch = jest.spyOn(store, 'dispatch');
+        userEvent.clear(screen.getByLabelText("Enter Project ID"));
         userEvent.type(screen.getByLabelText("Enter Project ID"), "2");
         await userEvent.click(screen.getByText('View Analysis'));
         // Check that the switch to analysis page has not been dispatched; this implicitly tests the alert as well
@@ -83,6 +94,7 @@ describe('MainPage', () => {
         jest.spyOn(TranscriptAPI, "getAnalysis").mockImplementationOnce(() => {return {data: [{question: "a", children: {"b": 100,}}]}});
         renderComponent();
         const dispatch = jest.spyOn(store, 'dispatch');
+        userEvent.clear(screen.getByLabelText("Enter Project ID"));
         userEvent.type(screen.getByLabelText("Enter Project ID"), "2");
         await userEvent.click(screen.getByText('View Analysis'));
         // Check that if no transcript with the ID is stored in analyzedTranscripts, but it exists on the database, it properly dispatches reducers to store it

--- a/front-end/src/components/main-page/MainPage.test.js
+++ b/front-end/src/components/main-page/MainPage.test.js
@@ -76,7 +76,7 @@ describe('MainPage', () => {
         expect(dispatch).not.toHaveBeenCalledWith({ type: 'switchPage/openAnalysisPage' });
     });
 
-    it.only("should dispatch addAnalyzedTranscript when valid Project ID is entered and View Analysis button is clicked but the Project ID is not stored in this session's transcripts", async() => {
+    it("should dispatch addAnalyzedTranscript when valid Project ID is entered and View Analysis button is clicked but the Project ID is not stored in this session's transcripts", async() => {
         jest.spyOn(TranscriptAPI, "getAnalysis").mockImplementationOnce(() => {return [{question: "a", children: {"b": 100,}}]});
         renderComponent();
         const dispatch = jest.spyOn(store, 'dispatch');


### PR DESCRIPTION
## Pull Request Summary
<!-- Summarize what your PR does -->
Added input field below View Analysis button on main page that takes in a project ID string as input so the user can select a specific transcript to view from our DB. If no transcript with that ID exists, then an alert window pops up. A string must be in the input field in order for View Analysis to be enabled.

Some minimal styling was applied to the input field and the asymmetry is not as bad as i thought it would be.

2 tests do not pass, pls see below.

### Change types
<!-- Delete anything which does not apply to your PR -->
- [x] Non-breaking change
- [x] Adding tests
- [x] Front end change

### Testing
- [x] I have added testing to this PR <!-- check this off once youve submitted your PR -->
<!--Describe any testing methods that are not normal here-->

### How to manually test this PR (QA instructions)
There are (at least) two different transcripts in the DB with IDs 1 and 2. Try switching between those two, and also notice the alert that pops up if you input an invalid ID like 3.

## Questions
<!--Put any questions you want to ask here (mainly used to allow others to see your code)-->
1) **OUTDATED** There are two tests that fail - they are both in MainPage.test near the bottom and they mock TranscriptAPI.getAnalysis. The tests time out once I added those and I'm not sure how to fix that. as far as I can see, I mocked it in the same way that TranscriptAPI.post is mocked in the upload modal tests.

2) the uploaded transcript redux slice is still functional and correctly tracks whether one has been uploaded, but I removed any reference to it on the mainpage because we are no longer using that as a check for whether View Analysis should be disabled. Instead, you don't need to have uploaded a transcript in the current session to view an analyzed transcript - it just has to exist in the DB. I just want to confirm that this is correct and I did not accidentally remove an important feature.