### PR TITLE
merge fix for . character

### DIFF
--- a/back-end/helpers/get/intent_analyzer.js
+++ b/back-end/helpers/get/intent_analyzer.js
@@ -17,7 +17,7 @@ export default class IntentAnalyzer{
             if (result) {
                 newIntents.push(result);
             }
-        }
+        } 
         return newIntents;
     }
   
@@ -45,7 +45,7 @@ export default class IntentAnalyzer{
     #replacePeriods(map) {
       const newMap = {};
       Object.entries(map).forEach(([intent, percentage]) => {
-          const replacedIntent = intent.replaceAll("-DOT-", ".")
+          const replacedIntent = intent.replaceAll("-DOT-", ".");
           newMap[replacedIntent] = parseFloat(percentage); //casting .toFixed() string into a float
       });
       return newMap;

--- a/back-end/helpers/get/transcript_data_grouper.js
+++ b/back-end/helpers/get/transcript_data_grouper.js
@@ -40,6 +40,7 @@ export default class TranscriptDataGrouper {
      * @return number in [0, 1]
      */
     #generateSimilarityScore(comparedIntent) {
+        
         const splitIntent1 = this.intent.question.split(" ");
         const splitIntent2 = comparedIntent.question.split(" ");
         this.differentWordsIndices = [];
@@ -156,9 +157,9 @@ export default class TranscriptDataGrouper {
     }
 
     async #mergeTwoQuestions(intent1, intent2) {
-        let originalMergingIntent = await TranscriptDataGrouper.#IntentDao.getImmediateIntent({question: intent1.question, project_id: this.project_id});
-        let targetIntent = await TranscriptDataGrouper.#IntentDao.getImmediateIntent({question: intent2.question, project_id: this.project_id});
-
+        // need to replace "." for mongodb
+        let originalMergingIntent = await TranscriptDataGrouper.#IntentDao.getImmediateIntent({question: intent1.question.replaceAll(".", "-DOT-"), project_id: this.project_id});
+        let targetIntent = await TranscriptDataGrouper.#IntentDao.getImmediateIntent({question: intent2.question.replaceAll(".", "-DOT-"), project_id: this.project_id});
         targetIntent = targetIntent[0];
         originalMergingIntent = originalMergingIntent[0];
 
@@ -206,12 +207,12 @@ export default class TranscriptDataGrouper {
         for (const [_, num] of map) {
             total_children += num;
         }
-
         // Calculate the new percentages for the merged intents
         for (const [question, num] of map) {
             const newPercentage = Math.round((num / total_children).toFixed(2) * 100);
-            percentageMap[question] = newPercentage;
+            percentageMap[question.replaceAll("-DOT-", ".")] = newPercentage;
         }
+        
         return {percentageMap, total_children};
     }
 }

--- a/back-end/helpers/test-helpers/fileGenerator.js
+++ b/back-end/helpers/test-helpers/fileGenerator.js
@@ -23,7 +23,6 @@ export default class FileGenerator{
 
         const transcript = {"data": at};
         const jsonTranscript = JSON.stringify(transcript);
-        console.log("2")
         fs.writeFile("sample_transcript_test.json", jsonTranscript, (err) => {
             if (err)
               console.log(err);


### PR DESCRIPTION
Merger has an issue for intents with a "." that slipped past all of us. It caused mongo to not get any viable intent resulting in intents being sent to the FE without children. This should now be fixed. You can test this with id:lkdsf9. Sorry team this was an oversight from me :cry: 
